### PR TITLE
[Fix]score migration, nil:false, default:0

### DIFF
--- a/db/migrate/20221105093637_change_score_to_diaries.rb
+++ b/db/migrate/20221105093637_change_score_to_diaries.rb
@@ -1,0 +1,5 @@
+class ChangeScoreToDiaries < ActiveRecord::Migration[6.1]
+  def change
+    change_column :diaries, :score, :decimal, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_11_02_093855) do
+ActiveRecord::Schema.define(version: 2022_11_05_093637) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -59,7 +59,7 @@ ActiveRecord::Schema.define(version: 2022_11_02_093855) do
     t.string "image_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.decimal "score", precision: 5, scale: 3
+    t.decimal "score", precision: 5, scale: 3, default: "0.0", null: false
   end
 
   create_table "events", force: :cascade do |t|


### PR DESCRIPTION
・scoreのカラムに、nil:false、default:0の条件を追加
　そのため、以前に投稿されたものはscore=0にした。